### PR TITLE
Include URL in case of HTTP error

### DIFF
--- a/beancount_exchangerates/source.py
+++ b/beancount_exchangerates/source.py
@@ -52,10 +52,12 @@ class Source(source.Source):
         request.add_header('User-Agent', 'price-fetcher')
         try:
             response = urlopen(request)
-        except HTTPError:
+        except HTTPError as err:
             price = get_default(ticker)
             if not price:
-                raise
+                message = f"HTTP Error: {err.code} for URL: {err.url}"
+                new_exception = RuntimeError(message)
+                raise new_exception from err
             price_time = datetime.datetime.now(datetime.timezone.utc)
         else:
             result = json.loads(response.read().decode())


### PR DESCRIPTION
Instead of:

    urllib.error.HTTPError: HTTP Error 404: Not Found

it will now show:

    RuntimeError: HTTP Error: 404 for URL: https://api.frankfurter.app/latest?base=USD&symbols=RUB