### PR TITLE
Remove mention of completely broken exchangerate.host from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,22 @@
 # Beancount Exchange Rates
 
-Price source for [Beancount](http://furius.ca/beancount/) that can load data from <https://frankfurter.dev> or other providers with similar APIs, such as <https://fixer.io> or <https://exchangeratesapi.io> (both support more symbols than Frankfurter, but only support EUR as `base` currency, at least on their free plans).
+Price source for [Beancount](http://furius.ca/beancount/) that can load data from <https://frankfurter.dev> or other providers with similar APIs.
 
 ## Providers
 
-### frankfurter.dev
+### Frankfurter.dev
 
-List of supported currencies: https://api.frankfurter.dev/v1/currencies
+List of supported currencies: <https://api.frankfurter.dev/v1/currencies>
 
 No API key required.
+
+### ExchangeRatesAPI.io & Fixer.io
+
+<https://exchangeratesapi.io> or <https://fixer.io>:
+
+* Require an API key
+* Support more symbols than Frankfurter.dev; both the same, see <https://api.exchangeratesapi.io/symbols?access_key=...> and <https://data.fixer.io/api/symbols?access_key=...>
+* Only support EUR as `base` currency (at least on their free plans)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Beancount Exchange Rates
 
-Price source for [Beancount](http://furius.ca/beancount/) that can load data from <https://frankfurter.dev> or other providers with similar APIs, such as <https://fixer.io> or <https://exchangeratesapi.io>.
+Price source for [Beancount](http://furius.ca/beancount/) that can load data from <https://frankfurter.dev> or other providers with similar APIs, such as <https://fixer.io> or <https://exchangeratesapi.io> (both support more symbols than Frankfurter, but only support EUR as `base` currency, at least on their free plans).
 
 ## Providers
 
@@ -34,6 +34,8 @@ Evaluate source string with `bean-price`:
 
 ```
 PYTHONPATH=.:$PYTHONPATH bean-price --no-cache -e 'CHF:beancount_exchangerates/USD:CHF'
+
+EXCHANGERATE_API_URL=https://api.exchangeratesapi.io/v1/ EXCHANGERATE_ACCESS_KEY=... bean-price --no-cache -e 'EUR:beancount_exchangerates/EUR:XAU'
 ```
 
 Set price source for commodity in beancount file:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Beancount Exchange Rates
 
-Price source for [Beancount](http://furius.ca/beancount/) that can load data from https://frankfurter.dev or similar providers.
+Price source for [Beancount](http://furius.ca/beancount/) that can load data from <https://frankfurter.dev> or other providers with similar APIs.
 
 ## Providers
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Beancount Exchange Rates
 
-Price source for [Beancount](http://furius.ca/beancount/) that can load data from <https://frankfurter.dev> or other providers with similar APIs.
+Price source for [Beancount](http://furius.ca/beancount/) that can load data from <https://frankfurter.dev> or other providers with similar APIs, such as <https://fixer.io> or <https://exchangeratesapi.io>.
 
 ## Providers
 
@@ -42,3 +42,4 @@ Set price source for commodity in beancount file:
 1970-01-01 commodity USD
     price: "CHF:beancount_exchangerates/USD:CHF"
 ```
+


### PR DESCRIPTION
It appears that the https://exchangerate.host has completely changed since this was written, and I have found that this no longer works, thus removing this. (The https://frankfurter.dev alternative however appears to still be working; separate PRs will address minor changes needed for it.)