### PR TITLE
Fix 'Frankfurter' default provider URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ pip install https://github.com/xuhcc/beancount-exchangerates/archive/master.zip
 
 Source string format is `<quote-currency>:beancount_exchangerates/<base-currency>:<quote-currency>`.
 
-Default API base url is https://api.frankfurter.app. It can be changed using `EXCHANGERATE_API_URL` environment variable to any service that implements Fixer API.
+Default API base url is `https://api.frankfurter.dev/v1/`. It can be changed using `EXCHANGERATE_API_URL` environment variable (which should end with slash) to any service that implements Fixer API.
 
 Data source can be changed using `EXCHANGERATE_SOURCE` environment variable.
 

--- a/beancount_exchangerates/source.py
+++ b/beancount_exchangerates/source.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     from beancount.prices import source
 
-DEFAULT_PROVIDER = 'https://api.frankfurter.app'
+DEFAULT_PROVIDER = 'https://api.frankfurter.dev/v1/'
 EXCHANGERATE_API_URL = os.environ.get('EXCHANGERATE_API_URL', DEFAULT_PROVIDER)
 EXCHANGERATE_SOURCE = os.environ.get('EXCHANGERATE_SOURCE')
 EXCHANGERATE_DEFAULTS = os.environ.get('EXCHANGERATE_DEFAULTS')


### PR DESCRIPTION
As-is it does not appear to work anymore; with this fix, it does again.