### PR TITLE
Replace RUB by CHF in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ Check https://api.exchangerate.host/sources for the complete list of sources.
 Evaluate source string with `bean-price`:
 
 ```
-PYTHONPATH=.:$PYTHONPATH bean-price --no-cache -e 'RUB:beancount_exchangerates/USD:RUB'
+PYTHONPATH=.:$PYTHONPATH bean-price --no-cache -e 'CHF:beancount_exchangerates/USD:CHF'
 ```
 
 Set price source for commodity in beancount file:
 
 ```
 1970-01-01 commodity USD
-    price: "RUB:beancount_exchangerates/USD:RUB"
+    price: "CHF:beancount_exchangerates/USD:CHF"
 ```


### PR DESCRIPTION
Because RUB currently 404s on frankfurter.dev, but e.g. CHF [et al] do work.

It's because RUB is not (no longer) included in https://api.frankfurter.dev/v1/currencies.