### PR TITLE
Use hard-coded precision of 12 instead of 4

### DIFF
--- a/beancount_exchangerates/source.py
+++ b/beancount_exchangerates/source.py
@@ -18,7 +18,9 @@ EXCHANGERATE_SOURCE = os.environ.get('EXCHANGERATE_SOURCE')
 EXCHANGERATE_DEFAULTS = os.environ.get('EXCHANGERATE_DEFAULTS')
 
 
-def to_decimal(number, precision=4):
+# TODO Should really use the precision set on a commodity in Beancount instead of hard-coding something...
+# NB: The hard-coded precision of 12 is chosen because that's what Fixer.io & exchangeratesapi.io use for BTC.
+def to_decimal(number, precision=12):
     quant = D('0.' + '0' * precision)
     return D(number).quantize(quant)
 


### PR DESCRIPTION
@xuhcc how about this?

Or do you have to know how to do this better, and actually use the precision set on a commodity in Beancount? (I do not know how to do that.)